### PR TITLE
Fix encoder tests and install packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,17 @@
 [metadata]
 description-file = README.md
+
+[options]
+package_dir =
+    = src
+packages = find:
+install_requires =
+    numpy>=1.23
+    pyyaml>=6.0
+
+[options.extras_require]
+dev =
+    pytest
+    mypy
+    flake8
+    build

--- a/src/amt/cli.py
+++ b/src/amt/cli.py
@@ -1,7 +1,7 @@
 import argparse
 from .encoder import HypervectorEncoder
 from .adf_update import ADFMemory
-import yaml
+import yaml  # type: ignore
 
 def main():
     parser = argparse.ArgumentParser(prog="bhre")

--- a/src/amt/encoder.py
+++ b/src/amt/encoder.py
@@ -2,14 +2,18 @@
 import hashlib
 import numpy as np
 
+from typing import Sequence
+
+
 class HypervectorEncoder:
-    def __init__(self, dim: int, alpha):
+    def __init__(self, dim: int, alpha: Sequence[float]):
         self.dim = dim
-        self.alpha = np.array(alpha, dtype=float)
+        self.alpha: np.ndarray = np.array(alpha, dtype=float)
 
     def encode(self, text: str) -> np.ndarray:
         h = hashlib.sha256(text.encode()).digest()
         v = np.frombuffer(h[:self.dim], dtype=np.uint8).astype(np.float32)
         v = (v / 255.0) * 2.0 - 1.0
         v /= np.linalg.norm(v) + 1e-9
-        return np.sinc(v * self.alpha)
+        hv = np.sinc(v * self.alpha)
+        return np.asarray(hv, dtype=float)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,8 +1,12 @@
 import numpy as np
 from amt.encoder import HypervectorEncoder
 
-def test_encode_consistency():
-    enc = HypervectorEncoder(dim=6, alpha=[0.2]*6)
+
+def test_encode_shape_and_consistency():
+    enc = HypervectorEncoder(dim=6, alpha=[1.0] * 6)
     hv1 = enc.encode("foo")
     hv2 = enc.encode("foo")
+
+    # shape should be (6,) and deterministic
+    assert hv1.shape == (6,)
     assert np.allclose(hv1, hv2)


### PR DESCRIPTION
## Summary
- fix `test_encoder` to check shape and deterministic output
- install `amt` and `selfplay_chess` packages from `src/`
- annotate encoder internals for mypy and avoid missing yaml stubs

## Testing
- `pytest -q`
- `mypy src/amt`

------
https://chatgpt.com/codex/tasks/task_e_68522788321c8325b6f193983855c741