### PR TITLE
Add UI package and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          pip install -e .[dev]
+          pip install -e .[dev,examples,ui]
           pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
       - name: Lint: black
         run: black --check src tests
@@ -24,6 +24,4 @@ jobs:
       - name: Test suite
         run: pytest --maxfail=1 --disable-warnings -q
       - name: Build docs with MkDocs
-        run: |
-          pip install mkdocs mkdocs-material
-          mkdocs build --strict
+        run: mkdocs build --strict

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .DS_Store
 *.egg-info/
 site/
+local_pip/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	pip install -e .[dev]
+	pip install -e .[dev,examples,ui]
 
 lint:
 	black --check src tests
@@ -14,9 +14,7 @@ test:
 docs:
 	mkdocs build --strict
 
-docs-build: docs
-
 build:
 	python -m build
 
-.PHONY: install lint typecheck test docs docs-build build
+.PHONY: install lint typecheck test docs build

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -1,1 +1,3 @@
-Contents of current_paper.txt would go here.
+# Bayesian Hypervector Rule Embeddings
+
+Bayesian Hypervector Rule Embeddings (BHRE) map discrete tokens and rules to continuous vectors using a six dimensional separable sinc kernel with compact Fourier support. A dual-channel Adaptive Discrepancy Filter (ADF) memory stores positive and negative examples to produce similarity scores when querying. This approach was demonstrated on a chess proof-of-concept but is intended for any online, explainable embedding that does not rely on backpropagation.

--- a/examples/eval.py
+++ b/examples/eval.py
@@ -1,0 +1,14 @@
+"""Example evaluation script."""
+
+import argparse
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="model.chkpt")
+    args = parser.parse_args(argv)
+    print(f"Evaluating {args.model}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/selfplay/data/seed_data.pgn
+++ b/examples/selfplay/data/seed_data.pgn
@@ -1,0 +1,2 @@
+[Event "Seed"]
+1. e4 e5 2. Nf3 Nc6

--- a/examples/selfplay/data/training_log.csv
+++ b/examples/selfplay/data/training_log.csv
@@ -1,0 +1,2 @@
+episode,reward
+1,0

--- a/examples/train.py
+++ b/examples/train.py
@@ -1,0 +1,22 @@
+"""Example training loop using BHRE components."""
+
+import time
+from amt.encoder import HypervectorEncoder
+from amt.adf_update import ADFMemory
+
+
+def main() -> None:
+    enc = HypervectorEncoder(dim=6, alpha=[1.0] * 6)
+    mem = ADFMemory(dim=6)
+    samples = [
+        ("move:e2e4", True),
+        ("move:d7d5", False),
+    ]
+    for text, pos in samples:
+        hv = enc.encode(text)
+        mem.update(hv, positive=pos)
+        time.sleep(0.01)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,11 @@ dependencies = ["numpy>=1.23", "pyyaml>=6.0"]
 
 [project.scripts]
 bhre = "amt.cli:main"
+selfplay = "selfplay_chess.train:main"
+ui = "ui.app:main"
 
 [project.optional-dependencies]
-dev = ["pytest", "mypy", "flake8", "build", "mkdocs", "mkdocs-material"]
+dev = ["pytest", "mypy", "flake8", "mkdocs", "mkdocs-material"]
 torch = ["torch>=2.0", "torchvision>=0.14", "torchaudio>=2.0"]
 examples = ["transformers>=4.0", "python-chess>=1.7.0", "torchhd>=0.2.0"]
+ui = ["flask"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,8 @@ dev =
     pytest
     mypy
     flake8
-    build
+    mkdocs
+    mkdocs-material
 torch =
     torch>=2.0
     torchvision>=0.14
@@ -23,3 +24,5 @@ examples =
     transformers>=4.0
     python-chess>=1.7.0
     torchhd>=0.2.0
+ui =
+    flask

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Simple Flask UI package."""

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,0 +1,46 @@
+"""Flask web UI exposing BHRE operations."""
+
+from flask import Flask, jsonify, request
+
+from amt.encoder import HypervectorEncoder
+from amt.adf_update import ADFMemory
+
+app = Flask(__name__)
+encoder = HypervectorEncoder(dim=6, alpha=[1.0] * 6)
+memory = ADFMemory(dim=6)
+
+
+@app.route("/")
+def index() -> str:
+    return "OK"
+
+
+@app.get("/encode")
+def encode() -> any:
+    text = request.args.get("text", "")
+    hv = encoder.encode(text)
+    return jsonify(hv.tolist())
+
+
+@app.post("/update")
+def update() -> any:
+    data = request.get_json(force=True)
+    hv = encoder.encode(data.get("text", ""))
+    memory.update(hv, positive=bool(data.get("positive", True)))
+    return jsonify({"status": "updated"})
+
+
+@app.get("/similarity")
+def similarity() -> any:
+    text = request.args.get("text", "")
+    hv = encoder.encode(text)
+    scores = memory.similarity_table([hv])
+    return jsonify(scores)
+
+
+def main() -> None:
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def test_eval_help():
+    res = subprocess.run(
+        ["python", "examples/eval.py", "--help"],
+        capture_output=True,
+    )
+    assert res.returncode == 0

--- a/tests/test_import_all.py
+++ b/tests/test_import_all.py
@@ -1,0 +1,13 @@
+import pkgutil
+import importlib
+
+packages = ["amt", "selfplay_chess", "ui"]
+
+
+def test_import_all():
+    for pkg in packages:
+        module = importlib.import_module(pkg)
+        for loader, name, is_pkg in pkgutil.walk_packages(
+            module.__path__, prefix=pkg + "."
+        ):
+            importlib.import_module(name)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,7 @@
+from ui.app import app
+
+
+def test_root_endpoint():
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- integrate BHRE examples and docs
- add optional UI and selfplay scripts
- update packaging metadata and Makefile
- create tests for UI and examples

## Testing
- `pip install -e .[dev,examples,ui]`
- `make lint`
- `make test`
- `make docs`
- `bhre --config config.yaml`
- `selfplay`
- `FLASK_APP=ui.app flask run --port 5000`

------
https://chatgpt.com/codex/tasks/task_e_68528f07a3f08325bfb78c3ab2535861